### PR TITLE
Typescript support via new TsProcessor

### DIFF
--- a/dist/lib/commands/check.js
+++ b/dist/lib/commands/check.js
@@ -13,6 +13,8 @@ var _generic_command = _interopRequireDefault(require("./generic_command"));
 
 var _js_processor = _interopRequireDefault(require("../processors/js_processor"));
 
+var _ts_processor = _interopRequireDefault(require("../processors/ts_processor"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var red = _cliColor.default.red;
@@ -102,7 +104,8 @@ Check.prototype.run = function () {
 };
 
 Check.processors = {
-  JsProcessor: _js_processor.default
+  JsProcessor: _js_processor.default,
+  TsProcessor: _ts_processor.default
 };
 var _default = Check;
 exports.default = _default;

--- a/dist/lib/processors/ts_processor.js
+++ b/dist/lib/processors/ts_processor.js
@@ -1,0 +1,34 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _fs = _interopRequireDefault(require("fs"));
+
+var _parser = require("@babel/parser");
+
+var _js_processor = _interopRequireDefault(require("./js_processor"));
+
+var _i18nliner = _interopRequireDefault(require("../i18nliner"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function TsProcessor(translations, options) {
+  _js_processor.default.call(this, translations, options);
+}
+
+TsProcessor.prototype = Object.create(_js_processor.default.prototype);
+TsProcessor.prototype.constructor = TsProcessor;
+TsProcessor.prototype.defaultPattern = ["**/*.ts", "**/*.tsx"];
+
+TsProcessor.prototype.parse = function (source) {
+  return (0, _parser.parse)(source, {
+    plugins: [..._i18nliner.default.config.babylonPlugins, "typescript"],
+    sourceType: "module"
+  });
+};
+
+var _default = TsProcessor;
+exports.default = _default;

--- a/lib/commands/check.js
+++ b/lib/commands/check.js
@@ -3,6 +3,7 @@ import clc from "cli-color";
 import TranslationHash from "../extractors/translation_hash";
 import GenericCommand from "./generic_command";
 import JsProcessor from "../processors/js_processor";
+import TsProcessor from "../processors/ts_processor";
 
 var red = clc.red;
 var green = clc.green;
@@ -90,6 +91,6 @@ Check.prototype.run = function() {
   return this.isSuccess();
 };
 
-Check.processors = { JsProcessor };
+Check.processors = { JsProcessor, TsProcessor };
 
 export default Check;

--- a/lib/processors/ts_processor.js
+++ b/lib/processors/ts_processor.js
@@ -1,0 +1,20 @@
+import { parse } from "@babel/parser";
+import JsProcessor from "./js_processor";
+import I18nliner from "../i18nliner";
+
+function TsProcessor(translations, options) {
+  JsProcessor.call(this, translations, options);
+}
+
+TsProcessor.prototype = Object.create(JsProcessor.prototype);
+TsProcessor.prototype.constructor = TsProcessor;
+TsProcessor.prototype.defaultPattern = ["**/*.ts", "**/*.tsx"];
+
+TsProcessor.prototype.parse = function (source) {
+  return parse(source, {
+    plugins: [...I18nliner.config.babylonPlugins, "typescript"],
+    sourceType: "module",
+  });
+};
+
+export default TsProcessor;

--- a/test/commands/check_test.js
+++ b/test/commands/check_test.js
@@ -6,13 +6,26 @@ import {assert} from "chai";
 
 describe('Check', function() {
   describe(".run", function() {
-    it("should find errors", function() {
-      I18nliner.set('basePath', "test/fixtures", function() {
+    it("should find errors in js files", function() {
+      I18nliner.set('basePath', "test/fixtures/i18n_js", function() {
         var checker = new Check({silent: true});
         checker.run();
         assert.deepEqual(
           checker.translations.translations,
           {"welcome_name_4c6ebc3a": 'welcome, %{name}'}
+        );
+        assert.equal(checker.errors.length, 1);
+        assert.match(checker.errors[0], /^invalid signature/);
+      });
+    });
+
+    it("should find errors in ts files", function() {
+      I18nliner.set('basePath', "test/fixtures/i18n_ts", function() {
+        var checker = new Check({silent: true});
+        checker.run();
+        assert.deepEqual(
+          checker.translations.translations,
+          {"welcome_fname_45c9b6bf": 'welcome, %{fname}'}
         );
         assert.equal(checker.errors.length, 1);
         assert.match(checker.errors[0], /^invalid signature/);

--- a/test/fixtures/i18n_ts/invalid.ts
+++ b/test/fixtures/i18n_ts/invalid.ts
@@ -1,0 +1,4 @@
+var I18n = { t: (str: string, vars?: any) => str };
+var fname = 'fname';
+
+I18n.t('welcome, ' + fname);

--- a/test/fixtures/i18n_ts/valid.ts
+++ b/test/fixtures/i18n_ts/valid.ts
@@ -1,0 +1,4 @@
+var I18n = { t: (str: string, vars?: any) => str };
+var fname = 'fname';
+
+I18n.t('welcome, %{fname}', {fname: fname});


### PR DESCRIPTION
Typescript support was introduced with new TsProcessor built on the top of the existing JsProcessor. Default pattern was changed to support only `.ts `and `.tsx` files under this processor. TS processing is made via @babel/parser plugin "typescript" which is internal one and does not require additional packages.

No additional configuration required from consumers part.