### PR TITLE
fix eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,6 @@
     }]
   ],
   "targets": {
-    "node": "current"
+    "node": "14"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "rules": {


### PR DESCRIPTION
Sets babel node target version to 14 (previously it used the machine's
current version) and upgrades eslint ECMA version from 6 (2015) to 2020.