### PR TITLE
throw errors for unwrapped count values

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,6 @@
     }]
   ],
   "targets": {
-    "node": "current"
+    "node": "14"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 2020,
     "sourceType": "module"
   },
   "rules": {

--- a/lib/call_helpers.js
+++ b/lib/call_helpers.js
@@ -38,6 +38,33 @@ var CallHelpers = {
       this.isObject(defaultValue);
   },
 
+  validCount: function(optionsNode, node) {
+    const countNode = node || optionsNode?.properties?.find(p => p.key.name === 'count')?.value;
+    if (!countNode) {
+      return true;
+    }
+
+    switch(countNode.type) {
+      case 'StringLiteral':
+      case 'NullLiteral':
+        return false;
+      case 'NumericLiteral':
+        return true;
+      case 'Identifier':
+        return ['Number', 'parseInt', 'parseFloat'].includes(countNode.name);
+      case 'CallExpression':
+        return this.validCount(optionsNode, countNode.callee);
+      case 'LogicalExpression':
+        return this.validCount(optionsNode, countNode.right);
+      case 'ConditionalExpression':
+        return this.validCount(optionsNode, countNode.consequent) && this.validCount(optionsNode, countNode.alternate)
+      case 'MemberExpression':
+        return this.validCount(optionsNode, countNode.object) && this.validCount(optionsNode, countNode.property)
+      default:
+        return false
+    }
+  },
+
   inferKey: function(defaultValue, translateOptions) {
     if (this.validDefault(defaultValue)) {
       defaultValue = this.normalizeDefault(defaultValue, translateOptions);
@@ -99,28 +126,34 @@ var CallHelpers = {
       Utils.difference(pKeys, this.ALLOWED_PLURALIZATION_KEYS).length === 0;
   },
 
-  inferArguments: function(args, meta) {
+  inferArguments: function(args, argNodes, meta) {
     if (args.length === 2 && typeof args[1] === 'object' && args[1].defaultValue)
-      return args;
+      return [args, argNodes];
 
     var hasKey = this.isKeyProvided.apply(this, args);
     if (meta)
       meta.inferredKey = !hasKey;
-    if (!hasKey)
+    if (!hasKey) {
       args.unshift(null);
+      argNodes?.unshift(null)
+    }
 
     var defaultValue = null;
     var defaultOrOptions = args[1];
-    if (args[2] || typeof defaultOrOptions === 'string' || this.isPluralizationHash(defaultOrOptions))
+    if (args[2] || typeof defaultOrOptions === 'string' || this.isPluralizationHash(defaultOrOptions)) {
       defaultValue = args.splice(1, 1)[0];
-    if (args.length === 1)
+      argNodes?.splice(1, 1);
+    }
+    if (args.length === 1) {
       args.push({});
+      argNodes?.push(null);
+    }
     var options = args[1];
     if (defaultValue)
       options.defaultValue = defaultValue;
     if (!hasKey)
       args[0] = this.inferKey(defaultValue, options);
-    return args;
+    return [args, argNodes];
   },
 
   applyWrappers: function(string, wrappers) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -34,6 +34,7 @@ Errors.register('InvalidPluralizationKey');
 Errors.register('MissingPluralizationKey');
 Errors.register('InvalidPluralizationDefault');
 Errors.register('MissingInterpolationValue');
+Errors.register('InvalidCountValue');
 Errors.register('MissingCountValue');
 Errors.register('InvalidOptionKey');
 Errors.register('KeyAsScope');

--- a/lib/extensions/i18n_js.js
+++ b/lib/extensions/i18n_js.js
@@ -53,7 +53,7 @@ var extend = function(I18n) {
 
   I18n.translateWithoutI18nliner = I18n.translate;
   I18n.translate = function() {
-    var args = CallHelpers.inferArguments([].slice.call(arguments));
+    var [args] = CallHelpers.inferArguments([].slice.call(arguments));
     var key = args[0];
     var options = args[1];
     key = CallHelpers.normalizeKey(key, options);

--- a/lib/extractors/i18n_js_extractor.js
+++ b/lib/extractors/i18n_js_extractor.js
@@ -66,7 +66,7 @@ I18nJsExtractor.prototype.processCall = function(node, path) {
 I18nJsExtractor.prototype.processArguments = function(args) {
   var result = [];
   for (var i = 0, len = args.length; i < len; i++) {
-    result.push(this.evaluateExpression(args[i]));
+    result.push([this.evaluateExpression(args[i]), args[i]]);
   }
   return result;
 };

--- a/lib/extractors/translate_call.js
+++ b/lib/extractors/translate_call.js
@@ -77,13 +77,19 @@ TranslateCall.prototype.validateDefault = function() {
  * default_string [, options]
  * default_object, options
  **/
-TranslateCall.prototype.normalizeArguments = function(args) {
+TranslateCall.prototype.normalizeArguments = function(argTuples) {
+  const {args, argNodes} = argTuples.reduce((result, [arg, argNode]) => {
+    result.args.push(arg)
+    result.argNodes.push(argNode)
+    return result
+  }, {args: [], argNodes: []});
   if (!args.length)
     throw new Errors.InvalidSignature(this.line, args);
-
-  var others = this.inferArguments(args.slice(), this);
+  var [others, othersNodes] = this.inferArguments(args.slice(), argNodes.slice(), this);
   var key = this.key = others.shift();
+  othersNodes.shift()
   var options = this.options = others.shift();
+  this.optionsNode = othersNodes.shift()
 
   if (others.length)
     throw new Errors.InvalidSignature(this.line, args);
@@ -113,8 +119,12 @@ TranslateCall.prototype.validateInterpolationValues = function(key, defaultValue
 
 TranslateCall.prototype.validateOptions = function() {
   var options = this.options;
-  if (typeof this.defaultValue === 'object' && (!options || !options.count))
-    throw new Errors.MissingCountValue(this.line);
+  if (typeof this.defaultValue === 'object') {
+    if (!options || !options.count)
+      throw new Errors.MissingCountValue(this.line);
+    if (!this.validCount(this.optionsNode))
+      throw new Errors.InvalidCountValue(this.line, 'Values for `count` must be wrapped in parseInt/parseFloat or fall back to a numeric literal (i.e. `foo || 0`).');
+  }
   if (options) {
     for (var k in options) {
       if (typeof k !== 'string')

--- a/test/extensions/i18n_js_test.js
+++ b/test/extensions/i18n_js_test.js
@@ -30,7 +30,7 @@ describe("I18nJs extension", function() {
   extend(I18n);
 
   describe("translate", function() {
-    it("should should normalize the arguments passed into the original translate", function() {
+    it("should normalize the arguments passed into the original translate", function() {
       var spy = sinon.spy(I18n, "translateWithoutI18nliner");
       assert.equal(
         I18n.translate("Hello %{name}", {name: "bob"}),

--- a/test/extractors/i18n_js_extractor_test.js
+++ b/test/extractors/i18n_js_extractor_test.js
@@ -78,6 +78,136 @@ describe("I18nJsExtractor", function() {
         extract("I18n.t({one: '1', other: '2'})");
       }, Errors.MissingCountValue);
     });
+
+    it("should bail on a t call with an identifier count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("provides a helpful error message for invalid count errors", function() {
+      let errMsg = ''
+      try {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar})`);
+      } catch ({message}) {
+        errMsg = message
+      }
+      assert.match(errMsg, /Values for `count` must be wrapped in parseInt\/parseFloat or fall back to a numeric literal/)
+    });
+
+    it("should bail on a t call with a null literal count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: null})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with a undefined literal count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: undefined})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with a string literal count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: 'potato'})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with an OR expression with an invalid value on right-hand side for count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar || 'potato'})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with an AND expression with an invalid value on right-hand side for count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: 5 && myVar})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with ternary with an invalid consequent value for count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar ? myVar : 0})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with ternary with an invalid alternate value for count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar ? 1 : 'potato'})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with a custom named function call for count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: foo(bar)})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should bail on a t call with builtin named function call (not parseInt or parseFloat) for count", function() {
+      assert.throws(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: Number.isNaN(bar)})`);
+      }, Errors.InvalidCountValue);
+    });
+
+    it("should not bail when a variable named count is used without plurality", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t('fast', '%{count}Fast2Furious', {count: null})`)
+      })
+    });
+
+    it("should not bail on a t call with a number literal count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: 5})`);
+      });
+    });
+
+    it("should not bail on a t call with an OR expression with valid number on right-hand side for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar || 0})`);
+      });
+    });
+
+    it("should not bail on a t call with an AND expression with valid number on right-hand side for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar && 0})`);
+      });
+    });
+
+    it("should not bail on a t call with ternary with valid consequent and alternate values for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: myVar ? 1 : 0 })`);
+      });
+    });
+
+    it("should not bail on a t call with value passed to Number for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: Number('1') })`);
+      });
+    });
+
+    it("should not bail on a t call with value passed to parseInt for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: parseInt('1', 10) })`);
+      });
+    });
+
+    it("should not bail on a t call with value passed to parseFloat for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: parseFloat('1.23') })`);
+      });
+    });
+
+    it("should not bail on a t call with value passed to Number.parseInt for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: Number.parseInt('1', 10) })`);
+      });
+    });
+
+    it("should not bail on a t call with value passed to Number.parseFloat for count", function() {
+      assert.doesNotThrow(function() {
+        extract(`I18n.t({one: '1', other: '2'}, {count: Number.parseFloat('1.23') })`);
+      });
+    });
   });
 
   describe("custom translator implementations", () => {

--- a/test/extractors/translate_call_test.js
+++ b/test/extractors/translate_call_test.js
@@ -6,7 +6,8 @@ import I18nliner from "../../lib/i18nliner";
 
 describe("TranslateCall", function() {
   function call() {
-    return new TranslateCall(null, 't', [].slice.call(arguments));
+    const argsWithNodes = [].slice.call(arguments).map(arg => [arg, null])
+    return new TranslateCall(null, 't', argsWithNodes);
   }
 
   describe("signature", function() {


### PR DESCRIPTION
Adds more strict checking around values supplied for `count`, to reduce
instances of null/undefined values being passed to count.