### PR TITLE
misc: various fixes and improvements

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [18.x, 20.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -25,7 +25,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install -g npm@latest
     - run: npm ci
     - run: npm run build --workspaces --if-present
     - run: npm run test --workspaces

--- a/packages/i18nliner/bin/i18nliner
+++ b/packages/i18nliner/bin/i18nliner
@@ -1,6 +1,20 @@
 #!/usr/bin/env node
 
-var minimist = require('minimist');
-var argv = require('minimist')(process.argv.slice(2));
-var success = require('../dist/lib/main').default.Commands.run(argv._[0], argv);
-process.exit(success ? 0 : 1);
+const argv = require('minimist')(process.argv.slice(2));
+const Commands = require('../lib/commands')
+const {loadConfig} = require('../lib/config')
+
+loadConfig()
+
+switch (argv._[0]) {
+  case 'check':
+    (new Commands.Check(argv)).run() || (process.exitCode = 1);
+    break;
+  case 'export':
+    (new Commands.Export(argv)).run() || (process.exitCode = 1);
+    break;
+  default:
+    console.error(`invalid command: ${argv._[0]}`)
+    process.exit(1)
+}
+

--- a/packages/i18nliner/lib/processors/js_processor.js
+++ b/packages/i18nliner/lib/processors/js_processor.js
@@ -11,7 +11,7 @@ function JsProcessor(translations, options) {
 
 JsProcessor.prototype = Object.create(AbstractProcessor.prototype);
 JsProcessor.prototype.constructor = JsProcessor;
-JsProcessor.prototype.defaultPattern = "**/*.js";
+JsProcessor.prototype.defaultPattern = ["**/*.js", "**/*.jsx"];
 
 JsProcessor.prototype.checkContents = function(source) {
   var fileData = this.preProcess(source);

--- a/packages/i18nliner/package.json
+++ b/packages/i18nliner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/i18nliner",
   "description": "i18n made simple",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "homepage": "https://github.com/instructure/i18nliner-js",
   "bin": {

--- a/packages/i18nliner/package.json
+++ b/packages/i18nliner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@instructure/i18nliner",
   "description": "i18n made simple",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "license": "MIT",
   "homepage": "https://github.com/instructure/i18nliner-js",
   "bin": {


### PR DESCRIPTION
Hi,

I'm a member of the Canvas Studio team and recently we've discovered that we don't have translations for quite a few files inside Studio. As it turns out that's because in the process of migrating Studio from `webpack` to `vite`, we've replaced our `.js` component files with `.jsx` ones and `i18nliner` does not search for `.jsx` files in its default pattern.

Since it uses the `jsx` babel plugin by default and the `TsProcessor` has `.tsx` files enabled anyway I think this should be a pretty safe change to make.

While I was at it, I updated the GitHub CI workflow to make it work again and also fixed the default bin entrypoint to `i18nliner` (in it's current state it was searching for a module that did not exist for a long time now).

I also tried to slice the change into bite sized commits to make it cleaner.

Thanks in advance for taking a look!